### PR TITLE
Add StableDeref impls for no_std types, including alloc and spin types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,3 @@ An unsafe marker trait for types like Box and Rc that dereference to a stable ad
 default = ["std"]
 std = []
 alloc = []
-spin_mutex = [ "spin" ]
-
-[dependencies.spin]
-version = "0.4.5"
-optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,9 @@ An unsafe marker trait for types like Box and Rc that dereference to a stable ad
 [features]
 default = ["std"]
 std = []
+alloc = []
+spin_mutex = [ "spin" ]
 
-[dependencies]
+[dependencies.spin]
+version = "0.4.5"
+optional = true

--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@ This crate defines an unsafe marker trait, StableDeref, for container types whic
 It is intended to be used by crates such as [owning_ref](https://crates.io/crates/owning_ref) and [rental](https://crates.io/crates/rental), as well as library authors who wish to make their code interoperable with such crates. For example, if you write a custom Vec type, you can implement StableDeref, and then users will be able to use your custom Vec type together with owning_ref and rental.
 
 no_std support can be enabled by disabling default features (specifically "std"). In this case, the trait will not be implemented for the std types mentioned above, but you can still use it for your own types.
+
+Enable the "alloc" feature (with default-features disabled) to have this trait be implemented for the above types from the built-in `alloc` crate, specifically
+* `alloc::boxed::Box`
+* `alloc::vec::Vec`
+* `alloc::rc::Rc`
+* `alloc::arc::Arc`
+* `alloc::string::String`
+
+Enable the "spin_mutex" feature (with default-features disabled) to have this trait be implemented for the following types from the [spin](https://crates.io/crates/spin) crate:
+* `spin::MutexGuard`
+* `spin::RwLockReadGuard`
+* `spin::RwLockWriteGuard`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ Enable the "alloc" feature (with default-features disabled) to have this trait b
 * `alloc::arc::Arc`
 * `alloc::string::String`
 
-Enable the "spin_mutex" feature (with default-features disabled) to have this trait be implemented for the following types from the [spin](https://crates.io/crates/spin) crate:
-* `spin::MutexGuard`
-* `spin::RwLockReadGuard`
-* `spin::RwLockWriteGuard`
+For example, this crate can be built with alloc support via the following command:    
+`cargo build --no-default-features --features alloc`
+
+Or added as a `Cargo.toml` dependency as follows:
+```
+[dependencies.stable_deref_trait]
+version = "<version>"
+default-features = false
+features = [ "alloc" ]
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,18 @@ It is intended to be used by crates such as [owning_ref](https://crates.io/crate
 no_std support can be enabled by disabling default features (specifically "std"). In this case, the trait will not be implemented for the std types mentioned above, but you can still use it for your own types.
 */
 
+#![feature(alloc)]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
 extern crate core;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "spin")]
+extern crate spin;
 
 use core::ops::Deref;
 
@@ -129,42 +137,69 @@ pub unsafe trait CloneStableDeref: StableDeref + Clone {}
 // std types integration
 /////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "alloc")))]
 use std::boxed::Box;
-#[cfg(feature = "std")]
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::boxed::Box;
+
+#[cfg(all(feature = "std", not(feature = "alloc")))]
 use std::rc::Rc;
-#[cfg(feature = "std")]
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::rc::Rc;
+
+#[cfg(all(feature = "std", not(feature = "alloc")))]
 use std::sync::Arc;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::arc::Arc;
+
+#[cfg(all(feature = "std", not(feature = "alloc")))]
+use std::vec::Vec;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
+
+#[cfg(all(feature = "std", not(feature = "alloc")))]
+use std::string::String;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::string::String;
+
+
 #[cfg(feature = "std")]
 use std::sync::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
+#[cfg(feature = "spin")]
+use spin::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
+
+
 #[cfg(feature = "std")]
 use std::cell::{Ref, RefMut};
+#[cfg(not(feature = "std"))]
+use core::cell::{Ref, RefMut};
 
-#[cfg(feature = "std")]
+
+#[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<T: ?Sized> StableDeref for Box<T> {}
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<T> StableDeref for Vec<T> {}
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl StableDeref for String {}
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<T: ?Sized> StableDeref for Rc<T> {}
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<T: ?Sized> CloneStableDeref for Rc<T> {}
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<T: ?Sized> StableDeref for Arc<T> {}
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<T: ?Sized> CloneStableDeref for Arc<T> {}
 
-#[cfg(feature = "std")]
+// #[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<'a, T: ?Sized> StableDeref for Ref<'a, T> {}
-#[cfg(feature = "std")]
+// #[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<'a, T: ?Sized> StableDeref for RefMut<'a, T> {}
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "spin"))]
 unsafe impl<'a, T: ?Sized> StableDeref for MutexGuard<'a, T> {}
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "spin"))]
 unsafe impl<'a, T: ?Sized> StableDeref for RwLockReadGuard<'a, T> {}
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "spin"))]
 unsafe impl<'a, T: ?Sized> StableDeref for RwLockWriteGuard<'a, T> {}
 
 unsafe impl<'a, T: ?Sized> StableDeref for &'a T {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ It is intended to be used by crates such as [owning_ref](https://crates.io/crate
 no_std support can be enabled by disabling default features (specifically "std"). In this case, the trait will not be implemented for the std types mentioned above, but you can still use it for your own types.
 */
 
-#![feature(alloc)]
+#![cfg_attr(feature = "alloc", feature(alloc))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -23,9 +23,6 @@ extern crate core;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
-
-#[cfg(feature = "spin")]
-extern crate spin;
 
 use core::ops::Deref;
 
@@ -165,9 +162,6 @@ use alloc::string::String;
 
 #[cfg(feature = "std")]
 use std::sync::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
-#[cfg(feature = "spin")]
-use spin::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
-
 
 #[cfg(feature = "std")]
 use std::cell::{Ref, RefMut};
@@ -195,11 +189,11 @@ unsafe impl<T: ?Sized> CloneStableDeref for Arc<T> {}
 unsafe impl<'a, T: ?Sized> StableDeref for Ref<'a, T> {}
 // #[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<'a, T: ?Sized> StableDeref for RefMut<'a, T> {}
-#[cfg(any(feature = "std", feature = "spin"))]
+#[cfg(feature = "std")]
 unsafe impl<'a, T: ?Sized> StableDeref for MutexGuard<'a, T> {}
-#[cfg(any(feature = "std", feature = "spin"))]
+#[cfg(feature = "std")]
 unsafe impl<'a, T: ?Sized> StableDeref for RwLockReadGuard<'a, T> {}
-#[cfg(any(feature = "std", feature = "spin"))]
+#[cfg(feature = "std")]
 unsafe impl<'a, T: ?Sized> StableDeref for RwLockWriteGuard<'a, T> {}
 
 unsafe impl<'a, T: ?Sized> StableDeref for &'a T {}


### PR DESCRIPTION
As a `no_std` Rustacean, I needed this for my own purposes. But I figured it'd be pretty useful for other people too, especially if they're using `owning_ref` in their projects. 

Happy to make any changes you'd prefer. One thing is that I feel the way you set the default-features is a bit confusing and can lead to weird combinations of features, but I left it as is because I didn't want to break other crates using it. 

The new features are used like this: 
`cargo build --no-default-features --features alloc`    
`cargo build --no-default-features --features spin`