### PR TITLE
Fixes for the alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ An unsafe marker trait for types like Box and Rc that dereference to a stable ad
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
 alloc = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@ It is intended to be used by crates such as [owning_ref](https://crates.io/crate
 no_std support can be enabled by disabling default features (specifically "std"). In this case, the trait will not be implemented for the std types mentioned above, but you can still use it for your own types.
 */
 
-#![cfg_attr(feature = "alloc", feature(alloc))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,60 +132,41 @@ pub unsafe trait CloneStableDeref: StableDeref + Clone {}
 // std types integration
 /////////////////////////////////////////////////////////////////////////////
 
-#[cfg(all(feature = "std"))]
-use std::boxed::Box;
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-
-#[cfg(all(feature = "std"))]
-use std::rc::Rc;
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::rc::Rc;
-
-#[cfg(all(feature = "std"))]
-use std::sync::Arc;
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::sync::Arc;
-
-#[cfg(all(feature = "std"))]
-use std::vec::Vec;
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-
-#[cfg(all(feature = "std"))]
-use std::string::String;
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 
 
 #[cfg(feature = "std")]
 use std::sync::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
 
-#[cfg(feature = "std")]
-use std::cell::{Ref, RefMut};
-#[cfg(not(feature = "std"))]
 use core::cell::{Ref, RefMut};
 
 
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 unsafe impl<T: ?Sized> StableDeref for Box<T> {}
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 unsafe impl<T> StableDeref for Vec<T> {}
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 unsafe impl StableDeref for String {}
 
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 unsafe impl<T: ?Sized> StableDeref for Rc<T> {}
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 unsafe impl<T: ?Sized> CloneStableDeref for Rc<T> {}
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 unsafe impl<T: ?Sized> StableDeref for Arc<T> {}
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 unsafe impl<T: ?Sized> CloneStableDeref for Arc<T> {}
 
-// #[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<'a, T: ?Sized> StableDeref for Ref<'a, T> {}
-// #[cfg(any(feature = "std", feature = "alloc"))]
 unsafe impl<'a, T: ?Sized> StableDeref for RefMut<'a, T> {}
 #[cfg(feature = "std")]
 unsafe impl<'a, T: ?Sized> StableDeref for MutexGuard<'a, T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,27 +132,27 @@ pub unsafe trait CloneStableDeref: StableDeref + Clone {}
 // std types integration
 /////////////////////////////////////////////////////////////////////////////
 
-#[cfg(all(feature = "std", not(feature = "alloc")))]
+#[cfg(all(feature = "std"))]
 use std::boxed::Box;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;
 
-#[cfg(all(feature = "std", not(feature = "alloc")))]
+#[cfg(all(feature = "std"))]
 use std::rc::Rc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::rc::Rc;
 
-#[cfg(all(feature = "std", not(feature = "alloc")))]
+#[cfg(all(feature = "std"))]
 use std::sync::Arc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::sync::Arc;
 
-#[cfg(all(feature = "std", not(feature = "alloc")))]
+#[cfg(all(feature = "std"))]
 use std::vec::Vec;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::vec::Vec;
 
-#[cfg(all(feature = "std", not(feature = "alloc")))]
+#[cfg(all(feature = "std"))]
 use std::string::String;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::string::String;


### PR DESCRIPTION
Allow building on stable rust, and with both alloc and std enabled.

The third commit is cleanup only; I can remove it from the PR if you prefer.