### PR TITLE
Use SPDX license format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stable_deref_trait"
 version = "1.1.1"
 authors = ["Robert Grosse <n210241048576@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/storyyeller/stable_deref_trait"
 documentation = "https://docs.rs/stable_deref_trait/1.1.1/stable_deref_trait"


### PR DESCRIPTION
The use of `/` as a separator in the license field is deprecated.

https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields