### PR TITLE
Generialize impl of Cow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,12 +143,12 @@ use alloc::vec::Vec;
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 #[cfg(feature = "alloc")]
-use alloc::borrow::Cow;
+use alloc::borrow::{Cow, ToOwned};
 
 #[cfg(feature = "std")]
-use std::ffi::{CStr, CString, OsStr, OsString};
+use std::ffi::{CString, OsString};
 #[cfg(feature = "std")]
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 #[cfg(feature = "std")]
 use std::sync::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
 
@@ -169,15 +169,7 @@ unsafe impl StableDeref for OsString {}
 unsafe impl StableDeref for PathBuf {}
 
 #[cfg(feature = "alloc")]
-unsafe impl<'a> StableDeref for Cow<'a, str> {}
-#[cfg(feature = "alloc")]
-unsafe impl<'a, T: Clone> StableDeref for Cow<'a, [T]> {}
-#[cfg(feature = "std")]
-unsafe impl<'a> StableDeref for Cow<'a, Path> {}
-#[cfg(feature = "std")]
-unsafe impl<'a> StableDeref for Cow<'a, CStr> {}
-#[cfg(feature = "std")]
-unsafe impl<'a> StableDeref for Cow<'a, OsStr> {}
+unsafe impl<'a, B: 'a + ToOwned + ?Sized> StableDeref for Cow<'a, B> where B::Owned: StableDeref {}
 
 #[cfg(feature = "alloc")]
 unsafe impl<T: ?Sized> StableDeref for Rc<T> {}


### PR DESCRIPTION
## Safety
`Cow` is either `Borrowed` or `Owned`. This choice does not change unless `&mut`ated. Thus the safety is delegated to `&T` and `&B::Owned`.

## Backward Compatibility

For library users, `StableDeref` is not a [local trait](https://doc.rust-lang.org/reference/glossary.html#local-trait). By the [orphan rule](https://doc.rust-lang.org/reference/items/implementations.html#r-items.impl.trait.orphan-rule.general), `T0` must be a [local type](https://doc.rust-lang.org/reference/glossary.html#local-type). If `Cow` is a type argument, then it's not afffected by this new `impl StableDeref`. Otherwise, `Cow` is not local.